### PR TITLE
Fix: Install, do not update dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ it: cs test
 composer:
 	composer self-update
 	composer validate
-	composer update
+	composer install
 
 coverage: composer
 	vendor/bin/phpunit --configuration=test/Unit/phpunit.xml --coverage-text


### PR DESCRIPTION
This PR

* [x] runs `composer install` instead of `composer update` in `composer` target of `Makefile`

Follows #9.

🤦‍♂️ 