### PR TITLE
Fix: Move fixtures into dedicated namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,13 +61,13 @@ Use `Localheinz\Specification\AndSpecification` to compose a specification
 from specifications which all need to be satisfied:
 
 ```php
-use Foo\Bar;
-use Localheinz\Specification;
+use Localheinz\Specification\AndSpecification;
+use Localheinz\Specification\Test\Fixture;
 
-$specification = new Specification\AndSpecification(
-    new Bar\IsInstanceOfStdClass(),
-    new Bar\HasFooProperty(),
-    new Bar\HasBarProperty()
+$specification = new AndSpecification(
+    new Fixture\Specification\IsInstanceOfStdClass(),
+    new Fixture\Specification\HasFooProperty(),
+    new Fixture\Specification\HasBarProperty()
 );
 
 $candidate = new \stdClass();
@@ -84,13 +84,13 @@ Use `Localheinz\Specification\OrSpecification` to compose a specification
 from specifications where only one needs to be satisfied:
 
 ```php
-use Foo\Bar;
-use Localheinz\Specification;
+use Localheinz\Specification\OrSpecification;
+use Localheinz\Specification\Test\Fixture;
 
-$specification = new Specification\OrSpecification(
-    new Bar\IsInstanceOfStdClass(),
-    new Bar\HasFooProperty(),
-    new Bar\HasBarProperty()
+$specification = new OrSpecification(
+    new Fixture\Specification\IsInstanceOfStdClass(),
+    new Fixture\Specification\HasFooProperty(),
+    new Fixture\Specification\HasBarProperty()
 );
 
 $candidate = new \stdClass();
@@ -104,13 +104,13 @@ Use `Localheinz\Specification\NotSpecification` to compose a specification
 from specifications where none should be satisfied:
 
 ```php
-use Foo\Bar;
-use Localheinz\Specification;
+use Localheinz\Specification\NotSpecification;
+use Localheinz\Specification\Test\Fixture;
 
-$specification = new Specification\NotSpecification(
-    new Bar\IsInstanceOfStdClass(),
-    new Bar\HasFooProperty(),
-    new Bar\HasBarProperty()
+$specification = new NotSpecification(
+    new Fixture\Specification\IsInstanceOfStdClass(),
+    new Fixture\Specification\HasFooProperty(),
+    new Fixture\Specification\HasBarProperty()
 );
 
 $candidate = new \SplObjectStorage();
@@ -123,14 +123,16 @@ $specification->isSatisfiedBy($candidate); // true
 Mix and match all of the specifications to your need:
 
 ```php
-use Foo\Bar;
-use Localheinz\Specification;
+use Localheinz\Specification\AndSpecification;
+use Localheinz\Specification\NotSpecification;
+use Localheinz\Specification\OrSpecification;
+use Localheinz\Specification\Test\Fixture;
 
-$specification = new Specification\AndSpecification(
-    new Specification\NotSpecification(new Bar\IsInstanceOfStdClass()),
-    new Specification\OrSpecification(
-        new Bar\HasFooProperty(),
-        new Bar\HasBarProperty()
+$specification = new AndSpecification(
+    new NotSpecification(new Fixture\Specification\IsInstanceOfStdClass()),
+    new OrSpecification(
+        new Fixture\Specification\HasFooProperty(),
+        new Fixture\Specification\HasBarProperty()
     )
 );
 

--- a/test/Fixture/Candidate/Baz.php
+++ b/test/Fixture/Candidate/Baz.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * @link https://github.com/localheinz/specification
  */
 
-namespace Localheinz\Specification\Test\Integration\Asset;
+namespace Localheinz\Specification\Test\Fixture\Candidate;
 
 final class Baz
 {

--- a/test/Fixture/Specification/CandidateSpecification.php
+++ b/test/Fixture/Specification/CandidateSpecification.php
@@ -11,14 +11,11 @@ declare(strict_types=1);
  * @link https://github.com/localheinz/specification
  */
 
-namespace Localheinz\Specification\Test\Unit\Asset;
+namespace Localheinz\Specification\Test\Fixture\Specification;
 
 use Localheinz\Specification\SpecificationInterface;
 
-/**
- * @internal
- */
-final class Specification implements SpecificationInterface
+final class CandidateSpecification implements SpecificationInterface
 {
     /**
      * @var object

--- a/test/Fixture/Specification/HasBarProperty.php
+++ b/test/Fixture/Specification/HasBarProperty.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * @link https://github.com/localheinz/specification
  */
 
-namespace Localheinz\Specification\Test\Integration\Asset;
+namespace Localheinz\Specification\Test\Fixture\Specification;
 
 use Localheinz\Specification\SpecificationInterface;
 

--- a/test/Fixture/Specification/HasFooProperty.php
+++ b/test/Fixture/Specification/HasFooProperty.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * @link https://github.com/localheinz/specification
  */
 
-namespace Localheinz\Specification\Test\Integration\Asset;
+namespace Localheinz\Specification\Test\Fixture\Specification;
 
 use Localheinz\Specification\SpecificationInterface;
 

--- a/test/Fixture/Specification/IsInstanceOfStdClass.php
+++ b/test/Fixture/Specification/IsInstanceOfStdClass.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * @link https://github.com/localheinz/specification
  */
 
-namespace Localheinz\Specification\Test\Integration\Asset;
+namespace Localheinz\Specification\Test\Fixture\Specification;
 
 use Localheinz\Specification\SpecificationInterface;
 

--- a/test/Integration/SpecificationTest.php
+++ b/test/Integration/SpecificationTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Localheinz\Specification\Test\Integration;
 
 use Localheinz\Specification;
+use Localheinz\Specification\Test\Fixture;
 use PHPUnit\Framework;
 
 final class SpecificationTest extends Framework\TestCase
@@ -26,9 +27,9 @@ final class SpecificationTest extends Framework\TestCase
         $candidate->bar = 3.14;
 
         $specification = new Specification\AndSpecification(
-            new Asset\IsInstanceOfStdClass(),
-            new Asset\HasFooProperty(),
-            new Asset\HasBarProperty()
+            new Fixture\Specification\IsInstanceOfStdClass(),
+            new Fixture\Specification\HasFooProperty(),
+            new Fixture\Specification\HasBarProperty()
         );
 
         $this->assertTrue($specification->isSatisfiedBy($candidate));
@@ -41,9 +42,9 @@ final class SpecificationTest extends Framework\TestCase
         $candidate->introduction = 'Hello, my name is Jane';
 
         $specification = new Specification\OrSpecification(
-            new Asset\IsInstanceOfStdClass(),
-            new Asset\HasFooProperty(),
-            new Asset\HasBarProperty()
+            new Fixture\Specification\IsInstanceOfStdClass(),
+            new Fixture\Specification\HasFooProperty(),
+            new Fixture\Specification\HasBarProperty()
         );
 
         $this->assertTrue($specification->isSatisfiedBy($candidate));
@@ -54,9 +55,9 @@ final class SpecificationTest extends Framework\TestCase
         $candidate = new \SplObjectStorage();
 
         $specification = new Specification\NotSpecification(
-            new Asset\IsInstanceOfStdClass(),
-            new Asset\HasFooProperty(),
-            new Asset\HasBarProperty()
+            new Fixture\Specification\IsInstanceOfStdClass(),
+            new Fixture\Specification\HasFooProperty(),
+            new Fixture\Specification\HasBarProperty()
         );
 
         $this->assertTrue($specification->isSatisfiedBy($candidate));
@@ -64,13 +65,13 @@ final class SpecificationTest extends Framework\TestCase
 
     public function testMixAndMatchSpecifications()
     {
-        $candidate = new Asset\Baz();
+        $candidate = new Specification\Test\Fixture\Candidate\Baz();
 
         $specification = new Specification\AndSpecification(
-            new Specification\NotSpecification(new Asset\IsInstanceOfStdClass()),
+            new Specification\NotSpecification(new Fixture\Specification\IsInstanceOfStdClass()),
             new Specification\OrSpecification(
-                new Asset\HasFooProperty(),
-                new Asset\HasBarProperty()
+                new Fixture\Specification\HasFooProperty(),
+                new Fixture\Specification\HasBarProperty()
             )
         );
 

--- a/test/Unit/SpecificationTestCase.php
+++ b/test/Unit/SpecificationTestCase.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Localheinz\Specification\Test\Unit;
 
 use Localheinz\Specification\SpecificationInterface;
+use Localheinz\Specification\Test\Fixture;
 use PHPUnit\Framework;
 
 abstract class SpecificationTestCase extends Framework\TestCase
@@ -39,7 +40,7 @@ abstract class SpecificationTestCase extends Framework\TestCase
         $reflection = new \ReflectionClass($this->className());
 
         $specifications = \array_map(function ($isSatisfied) use ($candidate) {
-            return new Asset\Specification(
+            return new Fixture\Specification\CandidateSpecification(
                 $candidate,
                 $isSatisfied
             );


### PR DESCRIPTION
This PR

* [x] moes fixtures into a dedicated namespace