### PR TITLE
Fix: Use encrypted tokens only when available

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ before_install:
   - source .travis/xdebug.sh
   - xdebug-disable
   - composer validate
-  - composer config github-oauth.github.com $GITHUB_TOKEN
+  - if [[ -n "$GITHUB_TOKEN" ]]; then composer config github-oauth.github.com $GITHUB_TOKEN; fi
 
 install:
   - if [[ "$TRAVIS_PHP_VERSION" == "7.2" ]]; then composer remove --dev localheinz/php-cs-fixer-config; fi
@@ -56,7 +56,7 @@ script:
   - vendor/bin/phpunit --configuration=test/Integration/phpunit.xml
 
 after_success:
-  - if [[ "$WITH_COVERAGE" == "true" ]]; then vendor/bin/test-reporter --coverage-report=build/logs/clover.xml; fi
+  - if [[ "$WITH_COVERAGE" == "true" && -n "$CODECLIMATE_REPO_TOKEN" ]]; then vendor/bin/test-reporter --coverage-report=build/logs/clover.xml; fi
 
 notifications:
   email: false


### PR DESCRIPTION
This PR

* [x] uses encrypted `GITHUB_TOKEN` and `CODECLIMATE_REPO_TOKEN` only when they are available

💁‍♂️ Secure environment variables are not available in pull request builds of forks.

For reference, see

- https://github.com/travis-ci/travis-ci/issues/1946
- https://docs.travis-ci.com/user/pull-requests/#Pull-Requests-and-Security-Restrictions