### PR TITLE
Fix: Ignore MSI without mutations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -112,7 +112,7 @@ jobs:
         - mkdir -p $HOME/.infection
 
       script:
-        - vendor/bin/infection --min-covered-msi=100 --min-msi=100
+        - vendor/bin/infection --ignore-msi-with-no-mutations --min-covered-msi=100 --min-msi=100
 
 notifications:
   email: false


### PR DESCRIPTION
This PR

* [x] ignores an MSI without mutations

Follows #47.