### PR TITLE
Enhancement: Require localheinz/phpstan-rules

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     "infection/infection": "~0.11.2",
     "localheinz/composer-normalize": "^1.0.0",
     "localheinz/php-cs-fixer-config": "~1.17.0",
+    "localheinz/phpstan-rules": "~0.3.0",
     "localheinz/test-util": "~0.7.0",
     "phpstan/phpstan": "~0.10.5",
     "phpstan/phpstan-strict-rules": "~0.10.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a71bec8c3ca3d973f55ffddab083fe07",
+    "content-hash": "612008090b2e51ede8be00a4c69d781e",
     "packages": [],
     "packages-dev": [
         {
@@ -1132,6 +1132,58 @@
             "description": "Provides a configuration factory and multiple rule sets for friendsofphp/php-cs-fixer.",
             "homepage": "https://github.com/localheinz/php-cs-fixer-config",
             "time": "2018-11-27T07:03:30+00:00"
+        },
+        {
+            "name": "localheinz/phpstan-rules",
+            "version": "0.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/localheinz/phpstan-rules.git",
+                "reference": "e73d0627cc05d2606d8dba6b05b9df184cc6ad1e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/localheinz/phpstan-rules/zipball/e73d0627cc05d2606d8dba6b05b9df184cc6ad1e",
+                "reference": "e73d0627cc05d2606d8dba6b05b9df184cc6ad1e",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.1.0",
+                "php": "^7.1",
+                "phpstan/phpstan": "~0.10.5"
+            },
+            "require-dev": {
+                "infection/infection": "~0.11.1",
+                "localheinz/composer-normalize": "^1.0.0",
+                "localheinz/php-cs-fixer-config": "~1.16.1",
+                "localheinz/test-util": "~0.7.0",
+                "phpstan/phpstan-strict-rules": "~0.10.1",
+                "phpunit/phpunit": "^7.4.3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Localheinz\\PHPStan\\Rules\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Andreas Möller",
+                    "email": "am@localheinz.com"
+                }
+            ],
+            "description": "Provides additional rules for phpstan/phpstan.",
+            "homepage": "https://github.com/localheinz/phpstan-rules",
+            "keywords": [
+                "PHPStan",
+                "phpstan-extreme-rules",
+                "phpstan-rules"
+            ],
+            "time": "2018-11-25T10:14:39+00:00"
         },
         {
             "name": "localheinz/test-util",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,4 +1,5 @@
 includes:
+	- vendor/localheinz/phpstan-rules/rules.neon
 	- vendor/phpstan/phpstan-strict-rules/rules.neon
 	- vendor/phpstan/phpstan/conf/config.levelmax.neon
 


### PR DESCRIPTION
This PR

* [x] requires `localheinz/phpstan-rules`
* [x] includes `rules.neon` from `localheinz/phpstan-rules`